### PR TITLE
M110 fix to catch up with last line too

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5686,7 +5686,7 @@ inline void gcode_M109() {
  * M110: Set Current Line Number
  */
 inline void gcode_M110() {
-  if (code_seen('N')) gcode_LastN = code_value_long();
+  if (code_seen('N')) { gcode_N = code_value_long(); gcode_LastN = gcode_N; }
 }
 
 /**


### PR DESCRIPTION
M110 with N argument needs to affect not only gcode_N but also gcode_LastN. The current behavior for M110 is to set the given N arg as current line number, where in 1037 gcode_LastN is set to gcode_N from the M110 command. This may work in certain scenarios, but not in common, the lineno for M110 may be random and must not be in sequence. 

The Marlin documentation for M110 https://github.com/MarlinFirmware/Marlin/wiki/M110 is not precise with "line number" and "new line number". As seen for other gcode interpreters M110 Nx refers to current line, next command must be x+1. (http://reprap.org/wiki/G-code#M110:_Set_Current_Line_Number)

To achieve this in a common sense, setting gcode_LastN has to be done when processing the M110 args and it has to be equal to gcode_N to provide the usual M110 behavior.

(Hopefully I got this done right, first pull request I ever did ; )